### PR TITLE
add support for setting the port (#281)

### DIFF
--- a/exe/ExampleMain.hs
+++ b/exe/ExampleMain.hs
@@ -21,6 +21,7 @@ import Data.Text (Text)
 import Data.Time.LocalTime.TimeZone.Series
 import Prelude
 import System.Directory
+import System.Environment (lookupEnv)
 import TextShow
 import Text.Read (readMaybe)
 import qualified Data.ByteString.Lazy as LBS
@@ -51,7 +52,10 @@ main :: IO ()
 main = do
   setupLogs
   tzs <- loadTimeZoneSeries "/usr/share/zoneinfo/"
-  quickHttpServe $
+  p <- lookupEnv "PORT"
+  conf <- commandLineConfig $
+    maybe defaultConfig (`setPort` defaultConfig) (readMaybe =<< p)
+  httpServe conf $
     ifTop (writeBS "quack!") <|>
     route
       [ ("targets", method GET targetsHandler)
@@ -117,7 +121,7 @@ parseHandler tzs = do
           ]
 
     parseTimeZone :: Maybe ByteString -> Text
-    parseTimeZone = fromMaybe defaultTimeZone . fmap Text.decodeUtf8
+    parseTimeZone = maybe defaultTimeZone Text.decodeUtf8
 
     parseLocale :: ByteString -> Locale
     parseLocale x = maybe defaultLocale (`makeLocale` mregion) mlang
@@ -141,3 +145,4 @@ parseHandler tzs = do
     parseLatent :: Maybe ByteString -> Bool
     parseLatent x = fromMaybe defaultLatent
       (readMaybe (Text.unpack $ Text.toTitle $ Text.decodeUtf8 $ fromMaybe empty x)::Maybe Bool)
+


### PR DESCRIPTION
Summary:
+ based on https://stackoverflow.com/a/51671356/630160 I have implemented:
    - passing in `--port=8080`
    - or setting PORT=8080 as environment variable
  where  `default < PORT < --port`, i.e. a --port parameter overrides both an environment variable and a default value, and an environment variable PORT overrides the default value.

+ change small hlint: `fromMaybe def . fmap f = `maybe def f`
Pull Request resolved: https://github.com/facebook/duckling/pull/281

Differential Revision: D13388735

Pulled By: patapizza

fbshipit-source-id: cbc4a819036dbec474526b862b0f6187f02b6155